### PR TITLE
UDP log fix

### DIFF
--- a/lib/udp_logger.rb
+++ b/lib/udp_logger.rb
@@ -5,6 +5,7 @@ module Merb::Rack
       @request_count = 0
       @app = app
       @sock = UDPSocket.open
+	  @hostname = `hostname --fqdn`.chomp
     end
   
     def deferred?(env)
@@ -19,7 +20,7 @@ module Merb::Rack
       req = Rack::Request.new(env)
       content_type = headers['Content-Type'] ? headers['Content-Type'].split(";").first : '-'
       timestamp = start.getutc.iso8601(2)[0..-2]
-      datagram = "#{req.port}.#{req.host} #{@request_count} #{timestamp} #{took} #{req.ip} TCP_MISS/#{status} #{body.size + headers.size} #{req.request_method.upcase} #{req.url} NONE/- #{content_type} #{env['HTTP_REFERRER'] || '-'} #{env['X-Forwarded-For'] || '-'} #{URI::encode(env['HTTP_USER_AGENT'] || '')}"
+      datagram = "#{@hostname} #{@request_count} #{timestamp} #{took} #{req.ip} TCP_MISS/#{status} #{body.size + headers.size} #{req.request_method.upcase} #{req.url} NONE/- #{content_type} #{env['HTTP_REFERRER'] || '-'} #{env['X-Forwarded-For'] || '-'} #{URI::encode(env['HTTP_USER_AGENT'] || '')}"
       
       @sock.send(datagram, 0, "208.80.152.138", 8420)
       


### PR DESCRIPTION
wikimedia-mobile's UDP logging breaks packet loss analysis (/trunk/udplog/srcmisc/packet-loss.cpp). Field 1 is the proxy hostname, not the virtual host. Each proxy hostname should send UDP packets with sequential sequence numbers. I think something along these lines should fix it.
