### PR TITLE
patch for jquery create odd element

### DIFF
--- a/public/javascripts/application.js
+++ b/public/javascripts/application.js
@@ -51,7 +51,7 @@ window.onorientationchange = updateOrientation;
 
 
 function wm_reveal_for_hash( hash ) {
- var targetel = $(hash)
+ var targetel = $('div.content_block [id]').filter(function(i){ return $(this).attr('id') === hash.substring(1); }).eq(0); 
  if(targetel) {
    var parentdiv = targetel.parents("div.content_block")
    if(parentdiv.length > 0 && ! parentdiv.is(':visible')) {


### PR DESCRIPTION
Some browser do not encode some charactors in location.hash.
And jQuery create element when they found out string like html-tag in argument.
So Passing location.hash as an argument to jQuery cause some issues ( xss, selector missfire, etc ).
